### PR TITLE
Use SFML events for keyboard input

### DIFF
--- a/src/setup/ControllerMap.hpp
+++ b/src/setup/ControllerMap.hpp
@@ -94,8 +94,11 @@ class ControllerMap {
 	ControllerMap operator=(ControllerMap const&) = delete;
 
 	/// @brief Update internal action states. Call once on tick update, and nowhere else.
-	/// @param has_focus Whether the game window has focus or not.
-	void update(bool has_focus);
+	void update();
+
+	/// @brief Process the SFML event given.
+	/// @details Used for keyboard controls. 
+	void handle_event(sf::Event const&);
 
 	/// @brief Returns whether there is a gamepad connected or not.
 	[[nodiscard]] auto gamepad_connected() const -> bool { return controller_handle != 0; }
@@ -143,6 +146,7 @@ class ControllerMap {
 	};
 	std::unordered_map<DigitalAction, DigitalActionData> digital_actions{};
 	std::unordered_map<AnalogAction, std::pair<InputAnalogActionHandle_t, AnalogActionStatus>> analog_actions{};
+	std::unordered_set<sf::Keyboard::Key> keys_pressed;
 	InputActionSetHandle_t platformer_action_set{};
 	InputActionSetHandle_t menu_action_set{};
 	InputActionSetHandle_t inventory_action_layer{};

--- a/src/setup/Game.cpp
+++ b/src/setup/Game.cpp
@@ -1,7 +1,7 @@
 #include "Game.hpp"
-#include "WindowManager.hpp"
 #include <steam/steam_api.h>
 #include <ctime>
+#include "WindowManager.hpp"
 
 namespace fornani {
 
@@ -151,6 +151,7 @@ void Game::run(bool demo, int room_id, std::filesystem::path levelpath, sf::Vect
 			default: break;
 			}
 			game_state.get_current_state().handle_events(services, event);
+			services.controller_map.handle_event(event);
 			if (valid_event) { ImGui::SFML::ProcessEvent(event); }
 			valid_event = true;
 		}
@@ -162,7 +163,7 @@ void Game::run(bool demo, int room_id, std::filesystem::path levelpath, sf::Vect
 		services.music.update();
 		bool has_focus = services.window->get().hasFocus();
 		services.ticker.tick([this, has_focus, &services = services] {
-			services.controller_map.update(has_focus);
+			services.controller_map.update();
 			game_state.get_current_state().tick_update(services);
 		});
 		game_state.get_current_state().frame_update(services);


### PR DESCRIPTION
Previously we were using `sf::Keyboard::is_pressed` (my bad), which could mean that it could get flagged as a keylogger for reading input when the game was not in focus. This small PR fixes that.