### PR TITLE
Fix unknown keyboard codes triggering all unbound actions

### DIFF
--- a/src/setup/ControllerMap.cpp
+++ b/src/setup/ControllerMap.cpp
@@ -142,7 +142,9 @@ void ControllerMap::handle_event(sf::Event const& event) {
 		if (last_controller_ty_used != ControllerType::keyboard) { reset_digital_action_states(); }
 		last_controller_ty_used = ControllerType::keyboard;
 
-		keys_pressed.insert(event.key.code);
+		if (event.key.code != sf::Keyboard::Key::Unknown) {
+			keys_pressed.insert(event.key.code);
+		}
 	} else if (event.type == sf::Event::KeyReleased) {
 		keys_pressed.erase(event.key.code);
 	}


### PR DESCRIPTION
Reported via discord:
![Screenshot_20241213_230114](https://github.com/user-attachments/assets/416f2add-5824-4ac4-97d0-011a6fc6a7d7)

Happened because those keys are not assigned a keycode and as such they trigger all unbound actions (which are assigned to the Unknown keycode as well)